### PR TITLE
Add statistics practice category to XAI app

### DIFF
--- a/Explainable AI (XAI)/README.md
+++ b/Explainable AI (XAI)/README.md
@@ -1,12 +1,11 @@
-# Linear Regression Learning Platform
+# Linear Regression & Statistics Learning Platform
 
-An interactive web application designed to help students, researchers, and practitioners learn and visualize how linear regression works from first principles. The platform demonstrates:
+An interactive web application designed to help students, researchers, and practitioners learn and visualize core statistical ideas from first principles. The platform now offers two categories:
 
-- Ordinary Least Squares (OLS)
-- Gradient Descent (GD)
-- Sum of Squares decomposition (TSS, ESS, RSS)
+- **Regression** – explore Ordinary Least Squares, Gradient Descent, and manual derivations with interactive plots.
+- **Statistics** – compute correlation, covariance, Welch's t-test, and one-way ANOVA from custom numeric inputs.
 
-This makes abstract statistical concepts easier to understand by coupling equations with interactive visualizations.
+This makes abstract statistical concepts easier to understand by coupling equations with interactive visualizations and concise numerical summaries.
 
 
 ## Setup
@@ -16,4 +15,5 @@ Clone the repository, install dependencies, and run the application locally:
 ```bash
 pip install -r requirements.txt
 python src/app.py
+```
 

--- a/Explainable AI (XAI)/src/index.html
+++ b/Explainable AI (XAI)/src/index.html
@@ -15,173 +15,232 @@
     <div class="hint">Click to add • Drag to move • Right-click to delete</div>
   </div>
 
-  <div class="tabs">
-    <div class="tab active" data-tab="ols">OLS</div>
-    <div class="tab" data-tab="gd">Gradient Descent</div>
-    <div class="tab" data-tab="manual">Manual</div>
+  <div class="category-tabs">
+    <div class="category-tab active" data-category="regression">Regression</div>
+    <div class="category-tab" data-category="statistics">Statistics</div>
   </div>
 
-  <div class="panel">
-    <div class="controls">
-      <button id="clear">Clear</button>
-      <button id="sample">Sample</button>
-      <label><input id="residuals" type="checkbox" checked> Residuals</label>
-      <span><strong>Points: </strong><span id="point-count">0</span></span>
+  <div class="category-content active" id="category-regression">
+    <div class="tabs">
+      <div class="tab active" data-tab="ols">OLS</div>
+      <div class="tab" data-tab="gd">Gradient Descent</div>
+      <div class="tab" data-tab="manual">Manual</div>
     </div>
-  </div>
 
-  <!-- OLS Tab -->
-  <div class="tab-content active" id="tab-ols">
-    <div class="main-grid">
-      <div class="panel">
-        <canvas id="plot-ols" width="800" height="500"></canvas>
+    <div class="panel">
+      <div class="controls">
+        <button id="clear">Clear</button>
+        <button id="sample">Sample</button>
+        <label><input id="residuals" type="checkbox" checked> Residuals</label>
+        <span><strong>Points: </strong><span id="point-count">0</span></span>
       </div>
-      <div>
+    </div>
+
+    <!-- OLS Tab -->
+    <div class="tab-content active" id="tab-ols">
+      <div class="main-grid">
         <div class="panel">
-          <h3>OLS</h3>
-          <button id="solve-ols" class="primary">Solve</button>
-          <div class="formula" id="ols-formula"></div>
-          <div class="values-grid">
-            <div class="value-box"><strong>m</strong><div id="ols-m">—</div></div>
-            <div class="value-box"><strong>b</strong><div id="ols-b">—</div></div>
-            <div class="value-box"><strong>R²</strong><div id="ols-r2">—</div></div>
-            <div class="value-box"><strong>MSE</strong><div id="ols-mse">—</div></div>
-          </div>
-          <div id="ols-calculations" style="display:none">
-            <h4>Steps</h4>
-            <div class="calculations" id="ols-steps"></div>
+          <canvas id="plot-ols" width="800" height="500"></canvas>
+        </div>
+        <div>
+          <div class="panel">
+            <h3>OLS</h3>
+            <button id="solve-ols" class="primary">Solve</button>
+            <div class="formula" id="ols-formula"></div>
+            <div class="values-grid">
+              <div class="value-box"><strong>m</strong><div id="ols-m">—</div></div>
+              <div class="value-box"><strong>b</strong><div id="ols-b">—</div></div>
+              <div class="value-box"><strong>R²</strong><div id="ols-r2">—</div></div>
+              <div class="value-box"><strong>MSE</strong><div id="ols-mse">—</div></div>
+            </div>
+            <div id="ols-calculations" style="display:none">
+              <h4>Steps</h4>
+              <div class="calculations" id="ols-steps"></div>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- GD Tab -->
-  <div class="tab-content" id="tab-gd">
-    <div class="main-grid">
-      <div class="panel">
-        <div class="gd-grid">
-          <div>
-            <div class="subtle">Data + Fit</div>
-            <canvas id="plot-gd" width="800" height="500"></canvas>
+    <!-- GD Tab -->
+    <div class="tab-content" id="tab-gd">
+      <div class="main-grid">
+        <div class="panel">
+          <div class="gd-grid">
+            <div>
+              <div class="subtle">Data + Fit</div>
+              <canvas id="plot-gd" width="800" height="500"></canvas>
+            </div>
+            <div>
+              <div class="subtle">Loss History</div>
+              <canvas id="loss-plot" width="380" height="500"></canvas>
+            </div>
           </div>
-          <div>
-            <div class="subtle">Loss History</div>
-            <canvas id="loss-plot" width="380" height="500"></canvas>
+        </div>
+        <div>
+          <div class="panel">
+            <h3>Gradient Descent</h3>
+            <div class="controls">
+              <button id="init-gd" class="warning">Initialize</button>
+              <button id="next-step" class="success" disabled>Next</button>
+              <button id="auto-run">Auto</button>
+              <button id="reset-gd">Reset</button>
+            </div>
+            <label>η: <input id="lr" type="number" step="0.01" value="0.1" min="0.001"></label>
+            <div class="iteration-info">
+              <strong>Iter: </strong><span id="iteration">0</span> •
+              <strong>Step: </strong><span id="current-step-name">Not Started</span>
+            </div>
+
+            <!-- GD Steps -->
+            <div class="step-info" id="step-0" style="display:none">
+              <div class="step-title">Step 0: Init</div>
+              <div class="formula" id="gd-init-formula"></div>
+            </div>
+            <div class="step-info" id="step-1" style="display:none">
+              <div class="step-title">Step 1: Predictions</div>
+              <div class="formula" id="gd-h-formula"></div>
+              <div class="table-container">
+                <table id="pred-table">
+                  <thead><tr><th>i</th><th>xᵢ</th><th>yᵢ</th><th>hᵢ</th><th>Error</th></tr></thead>
+                  <tbody id="pred-body"></tbody>
+                </table>
+              </div>
+            </div>
+            <div class="step-info" id="step-2" style="display:none">
+              <div class="step-title">Step 2: Cost</div>
+              <div class="formula" id="gd-j-formula"></div>
+              <div class="value-box"><strong>J</strong><div id="cost-value">—</div></div>
+            </div>
+            <div class="step-info" id="step-3" style="display:none">
+              <div class="step-title">Step 3: Gradients</div>
+              <div class="formula" id="gd-grads-formula"></div>
+              <div class="values-grid">
+                <div class="value-box"><strong>∂J/∂m</strong><div id="grad-m-val">—</div></div>
+                <div class="value-box"><strong>∂J/∂b</strong><div id="grad-b-val">—</div></div>
+              </div>
+            </div>
+            <div class="step-info" id="step-4" style="display:none">
+              <div class="step-title">Step 4: Update</div>
+              <div class="formula" id="gd-update-formula"></div>
+              <div class="values-grid">
+                <div class="value-box"><strong>New m</strong><div id="new-m-val">—</div></div>
+                <div class="value-box"><strong>New b</strong><div id="new-b-val">—</div></div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-      <div>
-        <div class="panel">
-          <h3>Gradient Descent</h3>
-          <div class="controls">
-            <button id="init-gd" class="warning">Initialize</button>
-            <button id="next-step" class="success" disabled>Next</button>
-            <button id="auto-run">Auto</button>
-            <button id="reset-gd">Reset</button>
-          </div>
-          <label>η: <input id="lr" type="number" step="0.01" value="0.1" min="0.001"></label>
-          <div class="iteration-info">
-            <strong>Iter: </strong><span id="iteration">0</span> •
-            <strong>Step: </strong><span id="current-step-name">Not Started</span>
-          </div>
+    </div>
 
-          <!-- GD Steps -->
-          <div class="step-info" id="step-0" style="display:none">
-            <div class="step-title">Step 0: Init</div>
-            <div class="formula" id="gd-init-formula"></div>
+    <!-- Manual Tab -->
+    <div class="tab-content" id="tab-manual">
+      <div class="main-grid">
+        <div class="panel">
+          <canvas id="plot-manual" width="800" height="500"></canvas>
+        </div>
+        <div>
+          <div class="panel">
+            <h3>Manual Stats</h3>
+            <button id="calculate-manual" class="primary">Calculate</button>
+            <div id="manual-calculations" style="display:none">
+              <h4>Means</h4>
+              <div class="calculations">
+                <div class="calc-step"><span id="mean-x-tex"></span></div>
+                <div class="calc-step"><span id="mean-y-tex"></span></div>
+              </div>
+              <h4>Sums of Squares</h4>
+              <div class="calculations">
+                <div class="calc-step"><span id="ssxx-tex"></span></div>
+                <div class="calc-step"><span id="ssyy-tex"></span></div>
+                <div class="calc-step"><span id="ssxy-tex"></span></div>
+              </div>
+              <h4>Coefficients</h4>
+              <div class="calculations">
+                <div class="calc-step"><span id="b1-tex"></span></div>
+                <div class="calc-step"><span id="b0-tex"></span></div>
+              </div>
+              <h4>Errors</h4>
+              <div class="calculations">
+                <div class="calc-step"><span id="tss-tex"></span></div>
+                <div class="calc-step"><span id="ess-tex"></span></div>
+                <div class="calc-step"><span id="rss-tex"></span></div>
+              </div>
+              <h4>Fit</h4>
+              <div class="calculations">
+                <div class="calc-step"><span id="r2-tex"></span></div>
+                <div class="calc-step"><span id="mse-tex"></span></div>
+                <div class="calc-step"><span id="rmse-tex"></span></div>
+              </div>
+              <div class="values-grid">
+                <div class="value-box"><strong>Final b₁</strong><div id="final-b1">—</div></div>
+                <div class="value-box"><strong>Final b₀</strong><div id="final-b0">—</div></div>
+              </div>
+            </div>
           </div>
-          <div class="step-info" id="step-1" style="display:none">
-            <div class="step-title">Step 1: Predictions</div>
-            <div class="formula" id="gd-h-formula"></div>
+          <div class="panel">
+            <h3>Data Table</h3>
             <div class="table-container">
-              <table id="pred-table">
-                <thead><tr><th>i</th><th>xᵢ</th><th>yᵢ</th><th>hᵢ</th><th>Error</th></tr></thead>
-                <tbody id="pred-body"></tbody>
+              <table id="manual-table">
+                <thead>
+                  <tr><th>i</th><th>xᵢ</th><th>yᵢ</th><th>x-x̄</th><th>y-ȳ</th><th>(x-x̄)²</th><th>(y-ȳ)²</th><th>(x-x̄)(y-ȳ)</th></tr>
+                </thead>
+                <tbody id="manual-body"></tbody>
               </table>
             </div>
           </div>
-          <div class="step-info" id="step-2" style="display:none">
-            <div class="step-title">Step 2: Cost</div>
-            <div class="formula" id="gd-j-formula"></div>
-            <div class="value-box"><strong>J</strong><div id="cost-value">—</div></div>
-          </div>
-          <div class="step-info" id="step-3" style="display:none">
-            <div class="step-title">Step 3: Gradients</div>
-            <div class="formula" id="gd-grads-formula"></div>
-            <div class="values-grid">
-              <div class="value-box"><strong>∂J/∂m</strong><div id="grad-m-val">—</div></div>
-              <div class="value-box"><strong>∂J/∂b</strong><div id="grad-b-val">—</div></div>
-            </div>
-          </div>
-          <div class="step-info" id="step-4" style="display:none">
-            <div class="step-title">Step 4: Update</div>
-            <div class="formula" id="gd-update-formula"></div>
-            <div class="values-grid">
-              <div class="value-box"><strong>New m</strong><div id="new-m-val">—</div></div>
-              <div class="value-box"><strong>New b</strong><div id="new-b-val">—</div></div>
-            </div>
-          </div>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- Manual Tab -->
-  <div class="tab-content" id="tab-manual">
-    <div class="main-grid">
+  <div class="category-content" id="category-statistics">
+    <div class="stats-grid">
       <div class="panel">
-        <canvas id="plot-manual" width="800" height="500"></canvas>
-      </div>
-      <div>
-        <div class="panel">
-          <h3>Manual Stats</h3>
-          <button id="calculate-manual" class="primary">Calculate</button>
-          <div id="manual-calculations" style="display:none">
-            <h4>Means</h4>
-            <div class="calculations">
-              <div class="calc-step"><span id="mean-x-tex"></span></div>
-              <div class="calc-step"><span id="mean-y-tex"></span></div>
-            </div>
-            <h4>Sums of Squares</h4>
-            <div class="calculations">
-              <div class="calc-step"><span id="ssxx-tex"></span></div>
-              <div class="calc-step"><span id="ssyy-tex"></span></div>
-              <div class="calc-step"><span id="ssxy-tex"></span></div>
-            </div>
-            <h4>Coefficients</h4>
-            <div class="calculations">
-              <div class="calc-step"><span id="b1-tex"></span></div>
-              <div class="calc-step"><span id="b0-tex"></span></div>
-            </div>
-            <h4>Errors</h4>
-            <div class="calculations">
-              <div class="calc-step"><span id="tss-tex"></span></div>
-              <div class="calc-step"><span id="ess-tex"></span></div>
-              <div class="calc-step"><span id="rss-tex"></span></div>
-            </div>
-            <h4>Fit</h4>
-            <div class="calculations">
-              <div class="calc-step"><span id="r2-tex"></span></div>
-              <div class="calc-step"><span id="mse-tex"></span></div>
-              <div class="calc-step"><span id="rmse-tex"></span></div>
-            </div>
-            <div class="values-grid">
-              <div class="value-box"><strong>Final b₁</strong><div id="final-b1">—</div></div>
-              <div class="value-box"><strong>Final b₀</strong><div id="final-b0">—</div></div>
-            </div>
-          </div>
+        <h3>Correlation & Covariance</h3>
+        <div class="input-group">
+          <label>X Values<textarea id="stats-x-input" placeholder="1, 2, 3"></textarea></label>
+          <label>Y Values<textarea id="stats-y-input" placeholder="2, 3, 4"></textarea></label>
+          <div class="hint small">Comma or newline separated numbers with equal length.</div>
         </div>
-        <div class="panel">
-          <h3>Data Table</h3>
-          <div class="table-container">
-            <table id="manual-table">
-              <thead>
-                <tr><th>i</th><th>xᵢ</th><th>yᵢ</th><th>x-x̄</th><th>y-ȳ</th><th>(x-x̄)²</th><th>(y-ȳ)²</th><th>(x-x̄)(y-ȳ)</th></tr>
-              </thead>
-              <tbody id="manual-body"></tbody>
-            </table>
-          </div>
+        <button id="compute-corr" class="primary">Compute</button>
+        <div class="formula" id="corr-formula"></div>
+        <div class="values-grid">
+          <div class="value-box"><strong>n</strong><div id="corr-n">—</div></div>
+          <div class="value-box"><strong>Cov</strong><div id="corr-cov">—</div></div>
+          <div class="value-box"><strong>r</strong><div id="corr-r">—</div></div>
+        </div>
+      </div>
+      <div class="panel">
+        <h3>Welch's t-test</h3>
+        <div class="input-group">
+          <label>Group A<textarea id="ttest-group-a" placeholder="5, 6, 7"></textarea></label>
+          <label>Group B<textarea id="ttest-group-b" placeholder="4, 8, 6"></textarea></label>
+          <div class="hint small">Two independent samples with at least two values each.</div>
+        </div>
+        <button id="compute-ttest" class="primary">Compute</button>
+        <div class="formula" id="ttest-formula"></div>
+        <div class="values-grid">
+          <div class="value-box"><strong>t</strong><div id="ttest-t">—</div></div>
+          <div class="value-box"><strong>df</strong><div id="ttest-df">—</div></div>
+          <div class="value-box"><strong>p (two-tailed)</strong><div id="ttest-p">—</div></div>
+        </div>
+      </div>
+      <div class="panel">
+        <h3>One-way ANOVA</h3>
+        <div class="anova-inputs">
+          <label>Group 1<textarea class="anova-group" placeholder="10, 11, 9"></textarea></label>
+          <label>Group 2<textarea class="anova-group" placeholder="12, 13, 11"></textarea></label>
+          <label>Group 3<textarea class="anova-group" placeholder="8, 9, 10"></textarea></label>
+        </div>
+        <div class="hint small">Provide at least two groups. Empty groups are ignored.</div>
+        <button id="compute-anova" class="primary">Compute</button>
+        <div class="formula" id="anova-formula"></div>
+        <div class="values-grid">
+          <div class="value-box"><strong>F</strong><div id="anova-f">—</div></div>
+          <div class="value-box"><strong>df₁</strong><div id="anova-df1">—</div></div>
+          <div class="value-box"><strong>df₂</strong><div id="anova-df2">—</div></div>
+          <div class="value-box"><strong>p</strong><div id="anova-p">—</div></div>
         </div>
       </div>
     </div>

--- a/Explainable AI (XAI)/src/static/app.js
+++ b/Explainable AI (XAI)/src/static/app.js
@@ -5,6 +5,7 @@
 class App {
   constructor() {
     this.points = [];
+    this.activeCategory = 'regression';
     this.activeTab = 'ols';
     this.showResiduals = true;
     this.models = {
@@ -12,12 +13,13 @@ class App {
       gd: {m: 0, b: 0, fitted: false},
       manual: {m: 0, b: 0, fitted: false}
     };
-    
+
     this.canvas = new CanvasHandler();
     this.olsSolver = new OLSSolver();
     this.gradientDescent = new GradientDescent();
     this.manualCalculator = new ManualCalculator();
-    
+    this.statisticsCalculator = new StatisticsCalculator();
+
     this.setupEventHandlers();
     this.initializeFormulas();
     this.canvas.draw(this.activeTab, this.points, this.models, this.showResiduals);
@@ -25,6 +27,10 @@ class App {
   }
 
   setupEventHandlers() {
+    document.querySelectorAll('.category-tab').forEach(tab => {
+      tab.addEventListener('click', () => this.switchCategory(tab.dataset.category));
+    });
+
     // Tabs
     document.querySelectorAll('.tab').forEach(tab => {
       tab.addEventListener('click', () => this.switchTab(tab.dataset.tab));
@@ -43,6 +49,30 @@ class App {
       this.showResiduals = e.target.checked;
       this.canvas.draw(this.activeTab, this.points, this.models, this.showResiduals);
     };
+
+    const corrBtn = document.getElementById('compute-corr');
+    if (corrBtn) corrBtn.onclick = () => this.computeCorrelation();
+    const ttestBtn = document.getElementById('compute-ttest');
+    if (ttestBtn) ttestBtn.onclick = () => this.computeTTest();
+    const anovaBtn = document.getElementById('compute-anova');
+    if (anovaBtn) anovaBtn.onclick = () => this.computeAnova();
+  }
+
+  switchCategory(category) {
+    if (this.activeCategory === category) return;
+    document.querySelectorAll('.category-tab').forEach(tab => tab.classList.remove('active'));
+    document.querySelectorAll('.category-content').forEach(cont => cont.classList.remove('active'));
+    const tab = document.querySelector(`.category-tab[data-category="${category}"]`);
+    const content = document.getElementById(`category-${category}`);
+    if (tab && content) {
+      tab.classList.add('active');
+      content.classList.add('active');
+      this.activeCategory = category;
+      if (category === 'regression') {
+        this.canvas.draw(this.activeTab, this.points, this.models, this.showResiduals);
+        this.canvas.drawLossPlot(this.gradientDescent.lossHistory);
+      }
+    }
   }
 
   switchTab(tab) {
@@ -181,6 +211,52 @@ class App {
       `\\frac{\\partial J}{\\partial m}=\\tfrac{1}{n}\\sum x_i(h_i-y_i),\\; \\frac{\\partial J}{\\partial b}=\\tfrac{1}{n}\\sum (h_i-y_i)`);
     AppUtils.kRender(document.getElementById('gd-update-formula'),
       `m\\leftarrow m-\\eta\\,\\tfrac{\\partial J}{\\partial m},\\; b\\leftarrow b-\\eta\\,\\tfrac{\\partial J}{\\partial b}`);
+    AppUtils.kRender(document.getElementById('corr-formula'),
+      `r=\\frac{\\sum (x_i-\\bar{x})(y_i-\\bar{y})}{\\sqrt{\\sum (x_i-\\bar{x})^2\\sum (y_i-\\bar{y})^2}}`);
+    AppUtils.kRender(document.getElementById('ttest-formula'),
+      `t=\\frac{\\bar{x}_1-\\bar{x}_2}{\\sqrt{\\tfrac{s_1^2}{n_1}+\\tfrac{s_2^2}{n_2}}}`);
+    AppUtils.kRender(document.getElementById('anova-formula'),
+      `F=\\frac{MS_B}{MS_W}=\\frac{\\tfrac{\\sum n_j(\\bar{x}_j-\\bar{x})^2}{k-1}}{\\tfrac{\\sum (x_{ij}-\\bar{x}_j)^2}{N-k}}`);
+  }
+
+  computeCorrelation() {
+    try {
+      const xs = AppUtils.parseNumberList(document.getElementById('stats-x-input').value);
+      const ys = AppUtils.parseNumberList(document.getElementById('stats-y-input').value);
+      const result = this.statisticsCalculator.correlation(xs, ys);
+      document.getElementById('corr-n').textContent = result.n;
+      document.getElementById('corr-cov').textContent = AppUtils.formatNumber(result.covariance);
+      document.getElementById('corr-r').textContent = AppUtils.formatNumber(result.correlation);
+    } catch (e) {
+      alert(e.message);
+    }
+  }
+
+  computeTTest() {
+    try {
+      const groupA = AppUtils.parseNumberList(document.getElementById('ttest-group-a').value);
+      const groupB = AppUtils.parseNumberList(document.getElementById('ttest-group-b').value);
+      const result = this.statisticsCalculator.tTest(groupA, groupB);
+      document.getElementById('ttest-t').textContent = AppUtils.formatNumber(result.t);
+      document.getElementById('ttest-df').textContent = AppUtils.formatNumber(result.df, 2);
+      document.getElementById('ttest-p').textContent = AppUtils.formatNumber(result.p, 4);
+    } catch (e) {
+      alert(e.message);
+    }
+  }
+
+  computeAnova() {
+    try {
+      const groups = Array.from(document.querySelectorAll('.anova-group'))
+        .map(el => AppUtils.parseNumberList(el.value));
+      const result = this.statisticsCalculator.anova(groups);
+      document.getElementById('anova-f').textContent = AppUtils.formatNumber(result.f);
+      document.getElementById('anova-df1').textContent = AppUtils.formatNumber(result.df1, 2);
+      document.getElementById('anova-df2').textContent = AppUtils.formatNumber(result.df2, 2);
+      document.getElementById('anova-p').textContent = AppUtils.formatNumber(result.p, 4);
+    } catch (e) {
+      alert(e.message);
+    }
   }
 }
 

--- a/Explainable AI (XAI)/src/static/solvers.js
+++ b/Explainable AI (XAI)/src/static/solvers.js
@@ -359,3 +359,184 @@ class ManualCalculator {
 window.OLSSolver = OLSSolver;
 window.GradientDescent = GradientDescent;
 window.ManualCalculator = ManualCalculator;
+
+// ============================================================================
+// STATISTICS CALCULATOR
+// ============================================================================
+
+class StatisticsCalculator {
+  constructor() {
+    this.lanczosCoefficients = [
+      676.5203681218851,
+      -1259.1392167224028,
+      771.32342877765313,
+      -176.61502916214059,
+      12.507343278686905,
+      -0.13857109526572012,
+      9.9843695780195716e-6,
+      1.5056327351493116e-7
+    ];
+  }
+
+  mean(values) {
+    if (!values.length) return 0;
+    return values.reduce((s, v) => s + v, 0) / values.length;
+  }
+
+  variance(values) {
+    if (values.length < 2) return 0;
+    const m = this.mean(values);
+    const ss = values.reduce((s, v) => s + (v - m) ** 2, 0);
+    return ss / (values.length - 1);
+  }
+
+  covariance(xs, ys) {
+    if (xs.length !== ys.length) throw new Error('X and Y must have the same length.');
+    if (xs.length < 2) throw new Error('Need at least two paired observations.');
+    const meanX = this.mean(xs);
+    const meanY = this.mean(ys);
+    let sum = 0;
+    for (let i = 0; i < xs.length; i++) {
+      sum += (xs[i] - meanX) * (ys[i] - meanY);
+    }
+    return sum / (xs.length - 1);
+  }
+
+  correlation(xs, ys) {
+    const cov = this.covariance(xs, ys);
+    const varX = this.variance(xs);
+    const varY = this.variance(ys);
+    if (varX <= 0 || varY <= 0) {
+      throw new Error('Variance is zero; correlation undefined.');
+    }
+    const corr = cov / Math.sqrt(varX * varY);
+    return {n: xs.length, covariance: cov, correlation: corr};
+  }
+
+  tTest(groupA, groupB) {
+    if (groupA.length < 2 || groupB.length < 2) {
+      throw new Error('Provide at least two values per group.');
+    }
+    const meanA = this.mean(groupA);
+    const meanB = this.mean(groupB);
+    const varA = this.variance(groupA);
+    const varB = this.variance(groupB);
+    const se = Math.sqrt(varA / groupA.length + varB / groupB.length);
+    if (!Number.isFinite(se) || se === 0) {
+      throw new Error('Standard error is zero; samples may be identical.');
+    }
+    const t = (meanA - meanB) / se;
+    const numerator = (varA / groupA.length + varB / groupB.length) ** 2;
+    const denominator =
+      (varA ** 2) / (groupA.length ** 2 * (groupA.length - 1)) +
+      (varB ** 2) / (groupB.length ** 2 * (groupB.length - 1));
+    const df = numerator / denominator;
+    const p = this.twoTailedPValue(t, df);
+    return {t, df, p};
+  }
+
+  anova(groups) {
+    const filtered = groups.filter(g => g.length > 0);
+    if (filtered.length < 2) {
+      throw new Error('Provide at least two non-empty groups.');
+    }
+    const totalN = filtered.reduce((s, g) => s + g.length, 0);
+    if (totalN <= filtered.length) {
+      throw new Error('Each group needs at least two observations.');
+    }
+    const means = filtered.map(g => this.mean(g));
+    const grandMean = filtered.reduce((s, g, i) => s + g.length * means[i], 0) / totalN;
+
+    let ssBetween = 0;
+    let ssWithin = 0;
+    filtered.forEach((group, idx) => {
+      ssBetween += group.length * (means[idx] - grandMean) ** 2;
+      ssWithin += group.reduce((s, v) => s + (v - means[idx]) ** 2, 0);
+    });
+
+    const dfBetween = filtered.length - 1;
+    const dfWithin = totalN - filtered.length;
+    if (dfWithin <= 0) {
+      throw new Error('Not enough data to estimate within-group variance.');
+    }
+    const msBetween = ssBetween / dfBetween;
+    const msWithin = ssWithin / dfWithin;
+    const f = msWithin === 0 ? Infinity : msBetween / msWithin;
+    const p = msWithin === 0 ? 0 : this.fTailProbability(f, dfBetween, dfWithin);
+    return {f, df1: dfBetween, df2: dfWithin, p};
+  }
+
+  logGamma(z) {
+    if (z < 0.5) {
+      return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * z)) - this.logGamma(1 - z);
+    }
+    z -= 1;
+    let x = 0.99999999999980993;
+    for (let i = 0; i < this.lanczosCoefficients.length; i++) {
+      x += this.lanczosCoefficients[i] / (z + i + 1);
+    }
+    const t = z + this.lanczosCoefficients.length - 0.5;
+    return 0.5 * Math.log(2 * Math.PI) + (z + 0.5) * Math.log(t) - t + Math.log(x);
+  }
+
+  beta(a, b) {
+    return Math.exp(this.logGamma(a) + this.logGamma(b) - this.logGamma(a + b));
+  }
+
+  tPDF(x, df) {
+    const half = 0.5 * (df + 1);
+    const logCoeff = this.logGamma(half) - this.logGamma(df / 2) - 0.5 * Math.log(df * Math.PI);
+    return Math.exp(logCoeff - half * Math.log(1 + (x * x) / df));
+  }
+
+  tCDF(value, df) {
+    if (!Number.isFinite(value)) return value > 0 ? 1 : 0;
+    if (df <= 0) return NaN;
+    const x = Math.abs(value);
+    if (x === 0) return 0.5;
+    const steps = Math.max(200, Math.min(2000, Math.ceil(x * 40)));
+    const h = x / steps;
+    let sum = 0;
+    for (let i = 0; i <= steps; i++) {
+      const weight = (i === 0 || i === steps) ? 1 : (i % 2 === 0 ? 2 : 4);
+      sum += weight * this.tPDF(i * h, df);
+    }
+    const integral = sum * h / 3;
+    const cdf = Math.min(1, Math.max(0, 0.5 + integral));
+    return value < 0 ? 1 - cdf : cdf;
+  }
+
+  twoTailedPValue(t, df) {
+    const cdf = this.tCDF(Math.abs(t), df);
+    return Math.max(0, Math.min(1, 2 * (1 - cdf)));
+  }
+
+  fPDF(x, d1, d2) {
+    if (x <= 0) return 0;
+    const half1 = d1 / 2;
+    const half2 = d2 / 2;
+    const logNumerator = half1 * Math.log(d1 / d2) + (half1 - 1) * Math.log(x);
+    const logDenominator = Math.log(this.beta(half1, half2)) + ((d1 + d2) / 2) * Math.log(1 + (d1 / d2) * x);
+    return Math.exp(logNumerator - logDenominator);
+  }
+
+  fCDF(value, d1, d2) {
+    if (!Number.isFinite(value)) return value > 0 ? 1 : 0;
+    if (value <= 0) return 0;
+    const steps = Math.max(400, Math.min(4000, Math.ceil(Math.sqrt(value) * 80)));
+    const h = value / steps;
+    let sum = 0;
+    for (let i = 0; i <= steps; i++) {
+      const weight = (i === 0 || i === steps) ? 1 : (i % 2 === 0 ? 2 : 4);
+      sum += weight * this.fPDF(i * h, d1, d2);
+    }
+    return Math.min(1, Math.max(0, sum * h / 3));
+  }
+
+  fTailProbability(f, d1, d2) {
+    const cdf = this.fCDF(f, d1, d2);
+    return Math.max(0, Math.min(1, 1 - cdf));
+  }
+}
+
+window.StatisticsCalculator = StatisticsCalculator;

--- a/Explainable AI (XAI)/src/static/styles.css
+++ b/Explainable AI (XAI)/src/static/styles.css
@@ -2,6 +2,11 @@
 body{margin:0;font:14px system-ui;background:#f8fafc;color:#0f172a}
 .container{max-width:1400px;margin:0 auto;padding:12px}
 .header{background:#fff;border-radius:8px;padding:16px;margin-bottom:12px;box-shadow:0 1px 3px #0001}
+.category-tabs{display:flex;gap:8px;margin:0 0 16px;flex-wrap:wrap}
+.category-tab{padding:10px 22px;border-radius:999px;background:#e2e8f0;color:#475569;font-weight:600;cursor:pointer;transition:background .2s,color .2s}
+.category-tab.active{background:#2563eb;color:#fff;box-shadow:0 2px 6px #1d4ed81a}
+.category-content{display:none}
+.category-content.active{display:block}
 .tabs{display:flex;border-bottom:2px solid #e2e8f0;margin-bottom:16px}
 .tab{padding:12px 24px;cursor:pointer;border-bottom:3px solid transparent;font-weight:500}
 .tab.active{border-bottom-color:#2563eb;color:#2563eb;background:#eff6ff}
@@ -26,6 +31,7 @@ input[type=checkbox]{margin-right:4px}
 .calc-step{margin:6px 0;font-size:13px}
 canvas{width:100%;height:auto;border:1px solid #e2e8f0;border-radius:6px;cursor:crosshair;display:block;touch-action:none}
 .hint{color:#64748b;font-size:12px;margin-top:8px}
+.hint.small{margin-top:4px}
 .current-step{background:#dcfce7;border-color:#16a34a}
 .table-container{max-height:300px;overflow-y:auto}
 table{width:100%;border-collapse:collapse;margin:8px 0;font-size:12px}
@@ -34,3 +40,9 @@ th{background:#f8fafc;font-weight:600}
 .gd-grid{display:grid;grid-template-columns:2fr 1fr;gap:12px;align-items:stretch}
 .subtle{color:#64748b;font-size:12px;margin:4px 0 8px}
 .iteration-info{background:#fef3c7;padding:12px;border-radius:6px;margin:12px 0}
+.stats-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:16px}
+.input-group label{display:block;font-weight:600;margin-bottom:8px}
+.input-group textarea{margin-top:6px}
+.anova-inputs{display:grid;gap:8px}
+textarea{width:100%;min-height:80px;border:1px solid #cbd5e1;border-radius:6px;padding:8px;font-family:inherit;font-size:14px;background:#f8fafc;resize:vertical}
+textarea:focus{outline:2px solid #2563eb;outline-offset:2px;background:#fff}

--- a/Explainable AI (XAI)/src/static/utils.js
+++ b/Explainable AI (XAI)/src/static/utils.js
@@ -41,6 +41,19 @@ function calculateR2(points, m, b) {
   return ssTot > 0 ? 1 - ssRes / ssTot : 0;
 }
 
+function parseNumberList(text) {
+  if (!text) return [];
+  return text
+    .split(/[\s,;]+/)
+    .map(v => parseFloat(v))
+    .filter(v => Number.isFinite(v));
+}
+
+function formatNumber(value, digits = 4) {
+  if (!Number.isFinite(value)) return '—';
+  return parseFloat(value.toFixed(digits)).toString();
+}
+
 // Domain utilities
 const domain = {xmin: 0, xmax: 10, ymin: 0, ymax: 10};
 const margin = 50;
@@ -63,8 +76,9 @@ function pxToData(px, py, canvas) {
 
 // Export for global access
 window.AppUtils = {
-  kRender, kFlush, calculateMSE, calculateR2, 
-  dataToPx, pxToData, domain, margin
+  kRender, kFlush, calculateMSE, calculateR2,
+  dataToPx, pxToData, domain, margin,
+  parseNumberList, formatNumber
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- reorganize the interface into regression and statistics categories for clarity
- add interactive correlation, covariance, Welch t-test, and one-way ANOVA calculators
- extend shared utilities and styles to support numeric parsing and formatted results

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6659aba88832580be74806017cd83